### PR TITLE
Display result content with text ellipsis

### DIFF
--- a/app/frontend/src/pages/Vector/Vector.module.css
+++ b/app/frontend/src/pages/Vector/Vector.module.css
@@ -55,7 +55,7 @@
     background: white;
     display: flex;
     margin-bottom: 1rem;
-    height: 275px;
+    height: auto;
 }
 
 .textContainer {
@@ -116,6 +116,18 @@
 }
 
 .approach {
-    font-size: 18px;
+    font-size: 16px;
     margin-left: 10px;
+    margin-top: 0;
+    margin-bottom: 5px;
+    font-weight: 500;
+}
+
+.content {
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 }

--- a/app/frontend/src/pages/Vector/Vector.tsx
+++ b/app/frontend/src/pages/Vector/Vector.tsx
@@ -196,26 +196,13 @@ const Vector: React.FC = () => {
                                                     )}
                                                 </Stack>
                                                 <p
-                                                    style={{ fontSize: "12px" }}
+                                                    className={styles.content}
                                                     dangerouslySetInnerHTML={{
-                                                        __html:
-                                                            (
-                                                                (result["@search.captions"]?.[0].highlights
-                                                                    ? result["@search.captions"][0].highlights.slice(0, 350)
-                                                                    : result["@search.captions"]?.[0].text
-                                                                    ? result["@search.captions"][0].text.slice(0, 350)
-                                                                    : result.content.slice(0, 300)) || ""
-                                                            ).length >= 300
-                                                                ? ((result["@search.captions"]?.[0].highlights
-                                                                      ? result["@search.captions"][0].highlights.slice(0, 350)
-                                                                      : result["@search.captions"]?.[0].text
-                                                                      ? result["@search.captions"][0].text.slice(0, 350)
-                                                                      : result.content.slice(0, 300)) || "") + "..."
-                                                                : (result["@search.captions"]?.[0].highlights
-                                                                      ? result["@search.captions"][0].highlights.slice(0, 350)
-                                                                      : result["@search.captions"]?.[0].text
-                                                                      ? result["@search.captions"][0].text.slice(0, 350)
-                                                                      : result.content.slice(0, 300)) || ""
+                                                        __html: result["@search.captions"]?.[0].highlights
+                                                            ? result["@search.captions"][0].highlights
+                                                            : result["@search.captions"]?.[0].text
+                                                            ? result["@search.captions"][0].text
+                                                            : result.content
                                                     }}
                                                 />
                                             </div>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR renders the result content with text ellipsis when it is too long to fit within the result container.

![image](https://github.com/Azure-Samples/azure-search-vector-search-demo/assets/140462121/94775869-6de5-4da7-b399-84a26da4b87f)
![image](https://github.com/Azure-Samples/azure-search-vector-search-demo/assets/140462121/a608d950-2643-4422-9e91-bcb5bcfca8f9)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[X ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Follow up work item: T[ask 2646537: Add 'show more' button after truncated content](https://msdata.visualstudio.com/Azure%20Search/_workitems/edit/2646537)