### PR TITLE
Delete links and reset result cards when changing dataset

### DIFF
--- a/app/frontend/src/pages/Vector/Vector.tsx
+++ b/app/frontend/src/pages/Vector/Vector.tsx
@@ -193,6 +193,7 @@ const Vector: React.FC = () => {
     );
 
     const onDatasetChange = React.useCallback((_event: React.FormEvent<HTMLDivElement>, item?: IDropdownOption): void => {
+        setResultCards([]);
         setSelectedDatasetKey(String(item?.key) ?? "sample");
     }, []);
 
@@ -242,11 +243,6 @@ const Vector: React.FC = () => {
                                                     <div className={styles.titleContainer}>
                                                         <p className={styles.searchResultCardTitle}>{result.title} </p>
                                                         {selectedDatasetKey === "sample" && <p className={styles.category}>{result.category}</p>}
-                                                        {selectedDatasetKey === "wikipedia" && (
-                                                            <a href={result.url} target="_blank" rel="noreferrer">
-                                                                {result.url && decodeURIComponent(result.url).slice(result.url?.lastIndexOf("/") + 1)}
-                                                            </a>
-                                                        )}
                                                     </div>
                                                     {!hideScores && (
                                                         <div className={styles.scoreContainer}>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR deletes links in results from wikipedia dataset and resets result cards to empty when the dataset is changed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Test at https://github.com/Azure/cognitive-search-vector-pr/blob/llamaindex/demo-python/code/azure-search-vector-python-llamaindex-sample.ipynb

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
run jupyter notebook cells
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->