### PR TITLE
Bump quart from 0.18.4 to 0.19.3

### DIFF
--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,6 +1,6 @@
 azure-identity==1.14.0
 azure-search-documents==11.4.0b6
-quart==0.18.4
+quart==0.19.3
 openai[datalib]==0.27.8
 uvicorn[standard]==0.23.2
 aiohttp==3.8.5


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR bumps quart from 0.18.4 to 0.19.3 to fix the deployment issue.
The instance https://app-backend-4r7tcbfeewbes.azurewebsites.net/ is working now.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->