### PR TITLE
'Azure AI Search' name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Azure Search Comparison Tool
+# Azure AI Search Comparison Tool
 
-This repository contains a React application that demonstrates the Azure Search Comparison Tool. This tool provides a web interface for visualizing different retrieval modes available in Azure Cognitive Search. Additionally, the tool supports image search using text-to-image and image-to-image search functionalities. It leverages Azure OpenAI for text embeddings and Azure AI Vision API for image embeddings.
+This repository contains a React application that demonstrates the Azure AI Search Comparison Tool. This tool provides a web interface for visualizing different retrieval modes available in Azure AI Search. Additionally, the tool supports image search using text-to-image and image-to-image search functionalities. It leverages Azure OpenAI for text embeddings and Azure AI Vision API for image embeddings.
 
 You can find a live demo at [aka.ms/VectorSearchDemo](https://aka.ms/VectorSearchDemo/)
 
@@ -8,14 +8,14 @@ You can find a live demo at [aka.ms/VectorSearchDemo](https://aka.ms/VectorSearc
 
 ## Features
 
-- Generate text embeddings using Azure OpenAI and insert them into a vector store in Azure Cognitive Search.
+- Generate text embeddings using Azure OpenAI and insert them into a vector store in Azure AI Search.
 - Perform vector search queries on text data, including vector searches with metadata filtering and hybrid (text + vectors) search.
 - Generate image embeddings using Azure AI Vision API.
 - Perform text-to-image and image-to-image vector searches.
 
 ## Prerequisites
 
-- An Azure subscription with access to Azure Cognitive Search and Azure AI Services.
+- An Azure subscription with access to Azure AI Search and Azure AI Services.
 - Access to Azure OpenAI for generating text embeddings.
 - Access to Azure AI Vision for generating image embeddings.
 
@@ -47,9 +47,9 @@ Execute the following commands, if you don't have any pre-existing Azure service
 
 1. Run `azd env set AZURE_OPENAI_SERVICE {Name of existing Azure OpenAI service}`
 1. Run `azd env set AZURE_OPENAI_DEPLOYMENT_NAME {Name of existing embedding model deployment}`. Only needed if your deployment is not the default 'embeddings'. Typically this'll be a text-embedding-ada-002 model.
-1. Run `azd env set AZURE_SEARCH_SERVICE_ENDPOINT {Endpoint of existing Azure Cognitive Search service}`
-1. Run `azd env set AZURE_SEARCH_TEXT_INDEX_NAME {Name of existing Azure Cognitive Search index with text}`
-1. Run `azd env set AZURE_SEARCH_IMAGE_INDEX_NAME {Name of existing Azure Cognitive Search index with images}`
+1. Run `azd env set AZURE_SEARCH_SERVICE_ENDPOINT {Endpoint of existing Azure AI Search service}`
+1. Run `azd env set AZURE_SEARCH_TEXT_INDEX_NAME {Name of existing Azure AI Search index with text}`
+1. Run `azd env set AZURE_SEARCH_IMAGE_INDEX_NAME {Name of existing Azure AI Search index with images}`
 1. Run `azd env set AZURE_VISIONAI_ENDPOINT {Endpoint of existing Azure AI Vision}`
 1. Run `azd env set AZURE_VISIONAI_KEY {Key of existing Azure AI Vision}`
 1. Run `azd up`
@@ -91,19 +91,19 @@ In a second terminal run the frontend:
 - In Azure: navigate to the Azure WebApp deployed by azd. The URL is printed out when azd completes (as "Endpoint"), or you can find it in the Azure portal.
 - Running locally: navigate to 127.0.0.1:50505
 
-1. The Azure Search Comparison Tool allows you to search for text queries by entering them in the search bar and pressing 'Enter'. The application will generate text embeddings using Azure OpenAI and perform vector searches on the data stored in Azure Cognitive Search.
+1. The Azure Search Comparison Tool allows you to search for text queries by entering them in the search bar and pressing 'Enter'. The application will generate text embeddings using Azure OpenAI and perform vector searches on the data stored in Azure AI Search.
 
-1. The search results will be displayed as cards. Feel free to click on the settings icon to explore the different query approaches such as Hybrid Search and Hybrid Search with Semantic Ranking, Captions, and Highlights powered by Microsoft Bing. Note that you will need to enroll in a Semantic Plan in your Azure Cognitive Search service to use this feature. See [Semantic search](https://learn.microsoft.com/azure/search/semantic-search-overview).
+1. The search results will be displayed as cards. Feel free to click on the settings icon to explore the different query approaches such as Hybrid Search and Hybrid Search with Semantic Ranking, Captions, and Highlights powered by Microsoft Bing. Note that you will need to enroll in a Semantic Plan in your Azure AI Search service to use this feature. See [Semantic search](https://learn.microsoft.com/azure/search/semantic-search-overview).
 
 ## Conclusion
 
-We hope you find this repository useful for demoing Vector search and exploring the different features Azure Cognitive Search has to offer. Feel free to explore and customize the code to meet your specific requirements.  
+We hope you find this repository useful for demoing Vector search and exploring the different features Azure AI Search has to offer. Feel free to explore and customize the code to meet your specific requirements.  
 If you have any questions or suggestions, please feel free to open an issue and we'll be happy to help.
 
 Happy searching!
 
 ## References
 
-- [Azure Cognitive Search Documentation](https://learn.microsoft.com/azure/search/)
+- [Azure AI Search Documentation](https://learn.microsoft.com/azure/search/)
 - [Azure OpenAI Documentation](https://learn.microsoft.com/azure/ai-services/openai/)
 - [Azure AI Vision Documentation](https://learn.microsoft.com/azure/ai-services/computer-vision/)


### PR DESCRIPTION
Renaming 'Azure Cognitive Search' to 'Azure AI Search'